### PR TITLE
Update rcon.inc

### DIFF
--- a/rcon.inc
+++ b/rcon.inc
@@ -1,9 +1,5 @@
-#include <a_samp>
-#include <YSF>
-
-#if !defined MAX_COMMANDS
-	#define MAX_COMMANDS 10
-#endif
+#tryinclude <a_samp>
+#tryinclude <YSF>
 
 #if !defined MAX_RCONS
 	#define MAX_RCONS 20
@@ -13,298 +9,243 @@
 	#define INVALID_RCON_ID -1
 #endif
 
-#if !defined MAX_IP_LEN
-	#define MAX_IP_LEN 32
+
+#if !defined INVALID_RCON_SLOT
+	#define INVALID_RCON_SLOT -1
 #endif
 
-enum g_rcon_data
-{
-	g_iIP[MAX_IP_LEN],
-	g_icommanddata[MAX_COMMANDS],
-	g_iUsed
+#if !defined MAX_IP_LEN
+	#define MAX_IP_LEN 16
+#endif
+
+#if !defined strcpy
+	#define strcpy(%0,%1,%2)    strcat((%0[0] = '\0',%0), %1, %2)
+#endif
+
+enum e_RCON_DATA {
+
+	e_iIP[MAX_IP_LEN]
 }
 
-new static g_iLogging;
-new static g_iRCON = 1;
-new static g_iWhitelisting = 1;
-new static g_iRCONData[MAX_RCONS][g_rcon_data];
+enum e_REMOTE_RCON_BOOLS:(<<= 1) {
 
-forward OnRemoteRCONFail(ipaddr[], port, password[], command[], reason);
-forward OnRemoteRCONExecuted(ipaddr[], port, password[], command[]);
-forward A_OnFilterScriptInit();
-
-public OnFilterScriptInit()
-{
-     if(!GetServerVarAsInt("rcon"))
-     {
-          printf("[WARNING]: RCON is disabled in server.cfg! Enable it.");
-     }
-
-     CallLocalFunction("A_OnFilterScriptInit", "", "");
-     return 1;
+	e_BOOL_iRCON = 1,
+	e_BOOL_iLogging,
+	e_BOOL_iWhitelisting,
+	e_BOOL_iInit
 }
+
+new static
+		g_iRCONData[MAX_RCONS][e_RCON_DATA],
+		e_REMOTE_RCON_BOOLS:g_iRCONBools;
+		
+
+static Ab_RCONInit() {
+
+	if(!GetConsoleVarAsInt("rcon"))
+	    print("[WARNING] : RCON is disabled in server.cfg! Enable it.");
+	    
+	for(new i = 0; i< MAX_RCONS; i++)
+	    g_iRCONData[i][e_iIP][0] = '\0';
+
+	g_iRCONBools |= e_BOOL_iRCON;
+	g_iRCONBools |= e_BOOL_iWhitelisting;
+	return 1;
+}
+
+public OnFilterScriptInit() {
+
+	if(!(g_iRCONBools & e_BOOL_iInit)) {
+	
+	    g_iRCONBools |= e_BOOL_iInit;
+	    Ab_RCONInit();
+	}
+	#if defined Ab_RCON_OnFilterScriptInit
+		return Ab_RCON_OnFilterScriptInit();
+	#else
+		return 1;
+	#endif
+}
+
+public OnGameModeInit() {
+
+	if(!(g_iRCONBools & e_BOOL_iInit)) {
+	
+	    g_iRCONBools |= e_BOOL_iInit;
+		Ab_RCONInit();
+	}
+	#if defined Ab_RCON_OnGameModeInit
+	    return Ab_RCON_OnGameModeInit();
+	#else
+	    return 1;
+	#endif
+}
+
 #if defined _ALS_OnFilterScriptInit
 	#undef OnFilterScriptInit
 #else
 	#define _ALS_OnFilterScriptInit
 #endif
 
-#define OnFilterScriptInit A_OnFilterScriptInit
-
-#if !defined strcpy
-	#if defined INCLUDE_STRCPY_FALSE
-	static strcpy(dest[], const src[], size = sizeof(dest))
-	{
-	    dest[0] = EOS;
-	    return strcat(dest, src, size);
-	}
-	#else
-	strcpy(dest[], const src[], size = sizeof(dest))
-	{
-    	dest[0] = EOS;
-    	return strcat(dest, src, size);
-	}
-	#endif
+#if defined _ALS_OnGameModeInit
+	#undef OnGameModeInit
+#else
+	#define _ALS_OnGameModeInit
 #endif
 
-public OnRemoteRCONPacket(const ipaddr[], port, const password[], success, const command[])
-{
-	new modifyableIP[MAX_IP_LEN], modifyablePassword[32], modifyableCommand[80], reason;
-	/*format(modifyableIP, sizeof(modifyableIP), "%s", ipaddr); // we have to do this since YSF makes the ipaddr var a constant
-	format(modifyablePassword, sizeof(modifyablePassword), "%s", password);
-	format(modifyableCommand, sizeof(modifyableCommand), "%s", command); -- Old method used for transferring the data */
+#define OnFilterScriptInit 	Ab_RCON_OnFilterScriptInit
+#define OnGameModeInit      Ab_RCON_OnGameModeInit
+
+#if defined Ab_RCON_OnFilterScriptInit
+	forward Ab_RCON_OnFilterScriptInit();
+#endif
+
+#if defined Ab_RCON_OnGameModeInit
+	forward Ab_RCON_OnGameModeInit();
+#endif
+
+
+public OnRemoteRCONPacket(const ipaddr[], port, const password[], success, const command[]) {
+
+	if(g_iRCONBools & e_BOOL_iRCON) {
 	
-	strcpy(modifyableIP, ipaddr, sizeof modifyableIP);
-	strcpy(modifyablePassword, password, sizeof modifyablePassword);
-	strcpy(modifyableCommand, command, sizeof modifyableCommand);
-	
-	if(g_iRCON)
-	{
-		if(g_iLogging)
-		{
-			if(!success)
-			{
-			    printf("IP: %s:%d(using password: %s) failed remote-RCON login.", ipaddr, port, password);
-			    printf("[RAW DETAILS]: %s,%d,%s,%d,%s", ipaddr, port, password, success, command);
+	    if(g_iRCONBools & e_BOOL_iLogging) {
+	    
+		    if(!success) {
+
+		        printf("IP : %s:%d(using password : %s) failed remote RCON login!", ipaddr, port, password);
+		        printf("[RAW DETAILS]: %s,%d,%s,%d,%s", ipaddr, port, password, success, command);
+				CallLocalFunction("OnRemoteRCONFail", "sissi", ipaddr, port, password, command, 2);
 			}
 		}
+		if(success) {
+		
+		    if(g_iRCONBools & e_BOOL_iWhitelisting) {
+		    
+		        if(IsIPWhitelisted(ipaddr)) {
+		        
+		            if(g_iRCONBools & e_BOOL_iLogging)
+		                printf("RCON Command executed by %s:%d(password : %s) - Command : %s", ipaddr, port, password, command);
 
-
-	    if(success)
-	    {
-	        if(g_iWhitelisting)
-			{
-				if(IsIPWhitelisted(modifyableIP))
-				{
-					/*new id = GetIPEnumInt(), command; // Command system in progress
-
-					if(strcmp(command, "NULL", true) == -1)
-					{
-						// No command was reported
-						command = 0;
+					CallLocalFunction("OnRemoteRCONExecuted", "siss", ipaddr, port, password, command);
+					
+	    			if(!OnRemoteRCONExecuted(ipaddr, port, password, command)) {
+	    			
+	    			    if(g_iRCONBools & e_BOOL_iLogging)
+	    			        printf("Command : \"%s\" dropped in OnRemoteRCONExecuted.", command);
+	    			        
+						return 0;
 					}
-
-					else
-					{
-						if(strcmp(command, "echo RCON admin connected to server.", true) == 0)
-						{
-						    command = 1; // Login
-						}
-					}*/
-
-					//if(g_iCommandData[command][permission] == 0) // Aren't denied the permission
-					//{
-
-					    if(g_iLogging) printf("Command executed by %s:%d(password: %s) - Command: %s.", ipaddr, port, password, command);
-						CallLocalFunction("OnRemoteRCONExecuted", ipaddr, port, password, command);
-
-						if(funcidx("OnRemoteRCONExecuted") > -1)
-						{
-							if(OnRemoteRCONExecuted(modifyableIP, port, modifyablePassword, modifyableCommand) == 0)
-							{
-								if(g_iLogging) printf("Command dropped in OnRemoteRCONExecuted.");
-								return 0;
-							}
-						}
-
-
-						return 1;
-					//}
+					return 1;
 				}
-				else
-				{
-					reason = 1;
-					CallLocalFunction("OnRemoteRCONFail", ipaddr, port, password, command, reason);
-					return 0; // drop the packet
+				else {
+				
+				    CallLocalFunction("OnRemoteRCONFail", "sissi", ipaddr, port, password, command, 1);
+				    return 0;
 				}
 			}
 		}
-
-		else
-		{
-			reason = 2;
-		    CallLocalFunction("OnRemoteRCONFail", ipaddr, port, password, command, reason);
-			return 0; // drop the packet
-		}
 	}
-
-	else
-	{
-		reason = 3;
-		CallLocalFunction("OnRemoteRCONFail", ipaddr, port, password, command, reason);
-		return 0; // Remote RCON isn't enabled.
+	else {
+	
+	    CallLocalFunction("OnRemoteRCONFail", "sissi", ipaddr, port, password, command, 3);
+		return 0;
 	}
-
 	return 1;
 }
 
-stock bool: ToggleLogging(bool: toggle)
-{
-	if(toggle == true)
-	{
-		g_iLogging = true;
-	}
+stock ToggleRCONLogging(bool:toggle) {
+
+	if(toggle)
+	    g_iRCONBools |= e_BOOL_iLogging;
 	else
-	{
-		g_iLogging = false;
-	}
-
-	return toggle;
+	    g_iRCONBools &= ~e_BOOL_iLogging;
+	return 1;
 }
 
-stock bool: ToggleRemoteRCON(bool: toggle)
-{
-	if(toggle == true)
-	{
-	    g_iRCON = 1;
-	}
+stock ToggleRemoteRCON(bool:toggle) {
 
+	if(toggle)
+	    g_iRCONBools |= e_BOOL_iRCON;
 	else
-	{
-	    g_iRCON = 0;
-	}
-
-	return toggle;
+	    g_iRCONBools &= ~e_BOOL_iRCON;
+	return 1;
 }
 
-stock bool: ToggleRemoteWhitelist(bool: toggle)
-{
-	if(toggle == true)
-	{
-	    g_iWhitelisting = 1;
-	}
+stock ToggleRemoteWhitelist(bool:toggle) {
 
+	if(toggle)
+	    g_iRCONBools |= e_BOOL_iWhitelisting;
 	else
-	{
-	    g_iWhitelisting = 0;
+	    g_iRCONBools &= ~e_BOOL_iWhitelisting;
+	return 1;
+}
+
+stock RCON_IsWhitelistingEnabled() 	return g_iRCONBools & e_BOOL_iWhitelisting;
+stock RCON_IsRemoteRCONEnabled()    return g_iRCONBools & e_BOOL_iRCON;
+stock RCON_IsLoggingEnabled()       return g_iRCONBools & e_BOOL_iLogging;
+
+
+stock GetFreeRCONSlot() {
+
+	for(new i = 0; i< MAX_RCONS; i++) {
+	
+	    if(g_iRCONData[i][e_iIP][0] == '\0')
+	        return i;
 	}
-
-	return toggle;
+	return INVALID_RCON_SLOT;
 }
+		
+static stock RCON_GetIPSlot(ip_address[]) {
 
-stock bool: RCON_IsWhitelistingEnabled()
-{
-	if(g_iWhitelisting)
-	    return true;
-
-	return false;
-}
-
-stock bool: RCON_IsRemoteRCONEnabled()
-{
-	if(g_iRCON)
-	    return true;
-
-	return false;
-}
-
-stock bool: RCON_IsLoggingEnabled()
-{
-	if(g_iLogging)
-	    return true;
-
-	return false;
-}
-
-stock GetFreeRCONSlot()
-{
-	new id = -1;
-	for (new i = 0; i != MAX_RCONS; ++i)
-	{
-		if(g_iRCONData[i][g_iUsed])
-		{
-			continue;
-		}
-
-		else
-		{
-			id = i;
-			break;
-		}
+	for(new i = 0; i< MAX_RCONS; i++) {
+	
+	    if(!strcmp(ip_address, g_iRCONData[i][e_iIP], true))
+	        return i;
 	}
-
-	return id;
+	return INVALID_RCON_SLOT;
 }
 
+stock IsIPWhitelisted(const ip_address[]) {
 
-stock WhitelistIP(ipaddr[])
-{
-	if(IsIPWhitelisted(ipaddr))
-	{
-	    return 1; // the IP is already whitelisted.
-	}
-
-	else
-	{
-	    new slot = GetFreeRCONSlot();
-
-		if(slot || slot == 0) // Will be -1 if none are avaliable
-		{
-			format(g_iRCONData[slot][g_iIP], MAX_IP_LEN, "%s", ipaddr);
-			g_iRCONData[slot][g_iUsed] = 1;
-
-			return 1;
-		}
-
-		else return 0;
-	}
-}
-
-stock UnwhitelistIPAddress(ipaddr[])
-{
-	if(IsIPWhitelisted(ipaddr)
-	{
-	    new slot = GetIPSlot(ipaddr);
-
-		g_iRCONData[i][g_iIP] = EOS;
-		g_iRCONData[i][g_iUsed] = 0;
-		return 1;
-	}
-
-	else return 0;
-}
-stock IsIPWhitelisted(ipaddr[])
-{
-    for (new i = 0; i != MAX_RCONS; ++i)
-	{
-	    if(strcmp(g_iRCONData[i][g_iIP], ipaddr, true) == 0)
-	    {
+	for(new i = 0; i< MAX_RCONS; i++) {
+	
+	    if(!strcmp(ip_address, g_iRCONData[i][e_iIP], true))
 	        return 1;
-		}
 	}
-
 	return 0;
 }
 
-stock GetIPSlot(ipaddr[])
-{
-    for (new i = 0; i != MAX_RCONS; ++i)
-	{
-	    if(strcmp(g_iRCONData[i][g_iIP], ipaddr, true) == 0)
-	    {
-	        return i;
-		}
-	}
+stock WhitelistIP(ip_address[]) {
 
-	return INVALID_RCON_SLOT;
+	if(IsIPWhitelisted(ip_address)) return 0;
+	
+	new
+	    temp_Slot = RCON_GetIPSlot(ip_address);
+
+	if(temp_Slot != INVALID_RCON_SLOT) {
+	
+	    strcpy(g_iRCONData[temp_Slot][e_iIP], ip_address, MAX_IP_LEN);
+		return 1;
+	}
+	return 0;
 }
+
+stock UnwhitelistIPAddress(ip_address[]) {
+
+	new
+	    temp_Slot = RCON_GetIPSlot(ip_address);
+
+	if(temp_Slot != INVALID_RCON_SLOT) {
+	
+	    g_iRCONData[temp_Slot][e_iIP][0] = '\0';
+	    return 1;
+	}
+	return 0;
+}
+
+
+forward OnRemoteRCONFail(const ipaddr[], port, const password[], const command[], reason);
+forward OnRemoteRCONExecuted(const ipaddr[], port, const password[], const command[]);
+
+

--- a/rcon.inc
+++ b/rcon.inc
@@ -38,13 +38,13 @@ enum e_REMOTE_RCON_BOOLS:(<<= 1) {
 new static
 		g_iRCONData[MAX_RCONS][e_RCON_DATA],
 		e_REMOTE_RCON_BOOLS:g_iRCONBools;
-		
+
 
 static Ab_RCONInit() {
 
 	if(!GetConsoleVarAsInt("rcon"))
 	    print("[WARNING] : RCON is disabled in server.cfg! Enable it.");
-	    
+
 	for(new i = 0; i< MAX_RCONS; i++)
 	    g_iRCONData[i][e_iIP][0] = '\0';
 
@@ -56,7 +56,7 @@ static Ab_RCONInit() {
 public OnFilterScriptInit() {
 
 	if(!(g_iRCONBools & e_BOOL_iInit)) {
-	
+
 	    g_iRCONBools |= e_BOOL_iInit;
 	    Ab_RCONInit();
 	}
@@ -70,7 +70,7 @@ public OnFilterScriptInit() {
 public OnGameModeInit() {
 
 	if(!(g_iRCONBools & e_BOOL_iInit)) {
-	
+
 	    g_iRCONBools |= e_BOOL_iInit;
 		Ab_RCONInit();
 	}
@@ -78,6 +78,59 @@ public OnGameModeInit() {
 	    return Ab_RCON_OnGameModeInit();
 	#else
 	    return 1;
+	#endif
+}
+
+public OnRemoteRCONPacket(const ipaddr[], port, const password[], success, const command[]) {
+
+	if(g_iRCONBools & e_BOOL_iRCON) {
+
+	    if(g_iRCONBools & e_BOOL_iLogging) {
+
+		    if(!success) {
+
+		        printf("IP : %s:%d(using password : %s) failed remote RCON login!", ipaddr, port, password);
+		        printf("[RAW DETAILS]: %s,%d,%s,%d,%s", ipaddr, port, password, success, command);
+				CallLocalFunction("OnRemoteRCONFail", "sissi", ipaddr, port, password, command, 2);
+			}
+		}
+		if(success) {
+
+		    if(g_iRCONBools & e_BOOL_iWhitelisting) {
+
+		        if(IsIPWhitelisted(ipaddr)) {
+
+		            if(g_iRCONBools & e_BOOL_iLogging)
+		                printf("RCON Command executed by %s:%d(password : %s) - Command : %s", ipaddr, port, password, command);
+
+					CallLocalFunction("OnRemoteRCONExecuted", "siss", ipaddr, port, password, command);
+
+	    			if(!OnRemoteRCONExecuted(ipaddr, port, password, command)) {
+
+	    			    if(g_iRCONBools & e_BOOL_iLogging)
+	    			        printf("Command : \"%s\" dropped in OnRemoteRCONExecuted.", command);
+
+						return 0;
+					}
+					return 1;
+				}
+				else {
+
+				    CallLocalFunction("OnRemoteRCONFail", "sissi", ipaddr, port, password, command, 1);
+				    return 0;
+				}
+			}
+		}
+	}
+	else {
+
+	    CallLocalFunction("OnRemoteRCONFail", "sissi", ipaddr, port, password, command, 3);
+		return 0;
+	}
+	#if defined Ab_RCON_OnRemoteRCONPacket
+	    return Ab_RCON_OnRemoteRCONPacket(ipaddr, port, password, success, command);
+	#else
+		return 1;
 	#endif
 }
 
@@ -93,8 +146,17 @@ public OnGameModeInit() {
 	#define _ALS_OnGameModeInit
 #endif
 
+#if defined _ALS_OnRemoteRCONPacket
+	#undef OnRemoteRCONPacket
+#else
+	#define _ALS_OnRemoteRCONPacket
+#endif
+
+
 #define OnFilterScriptInit 	Ab_RCON_OnFilterScriptInit
 #define OnGameModeInit      Ab_RCON_OnGameModeInit
+#define OnRemoteRCONPacket 	Ab_RCON_OnRemoteRCONPacket
+
 
 #if defined Ab_RCON_OnFilterScriptInit
 	forward Ab_RCON_OnFilterScriptInit();
@@ -104,55 +166,11 @@ public OnGameModeInit() {
 	forward Ab_RCON_OnGameModeInit();
 #endif
 
+#if defined Ab_RCON_OnRemoteRCONPacket
+	forward Ab_RCON_OnRemoteRCONPacket(const ipaddr[], port, const password[], success, const command[]);
+#endif
 
-public OnRemoteRCONPacket(const ipaddr[], port, const password[], success, const command[]) {
 
-	if(g_iRCONBools & e_BOOL_iRCON) {
-	
-	    if(g_iRCONBools & e_BOOL_iLogging) {
-	    
-		    if(!success) {
-
-		        printf("IP : %s:%d(using password : %s) failed remote RCON login!", ipaddr, port, password);
-		        printf("[RAW DETAILS]: %s,%d,%s,%d,%s", ipaddr, port, password, success, command);
-				CallLocalFunction("OnRemoteRCONFail", "sissi", ipaddr, port, password, command, 2);
-			}
-		}
-		if(success) {
-		
-		    if(g_iRCONBools & e_BOOL_iWhitelisting) {
-		    
-		        if(IsIPWhitelisted(ipaddr)) {
-		        
-		            if(g_iRCONBools & e_BOOL_iLogging)
-		                printf("RCON Command executed by %s:%d(password : %s) - Command : %s", ipaddr, port, password, command);
-
-					CallLocalFunction("OnRemoteRCONExecuted", "siss", ipaddr, port, password, command);
-					
-	    			if(!OnRemoteRCONExecuted(ipaddr, port, password, command)) {
-	    			
-	    			    if(g_iRCONBools & e_BOOL_iLogging)
-	    			        printf("Command : \"%s\" dropped in OnRemoteRCONExecuted.", command);
-	    			        
-						return 0;
-					}
-					return 1;
-				}
-				else {
-				
-				    CallLocalFunction("OnRemoteRCONFail", "sissi", ipaddr, port, password, command, 1);
-				    return 0;
-				}
-			}
-		}
-	}
-	else {
-	
-	    CallLocalFunction("OnRemoteRCONFail", "sissi", ipaddr, port, password, command, 3);
-		return 0;
-	}
-	return 1;
-}
 
 stock ToggleRCONLogging(bool:toggle) {
 
@@ -189,17 +207,17 @@ stock RCON_IsLoggingEnabled()       return g_iRCONBools & e_BOOL_iLogging;
 stock GetFreeRCONSlot() {
 
 	for(new i = 0; i< MAX_RCONS; i++) {
-	
+
 	    if(g_iRCONData[i][e_iIP][0] == '\0')
 	        return i;
 	}
 	return INVALID_RCON_SLOT;
 }
-		
+
 static stock RCON_GetIPSlot(ip_address[]) {
 
 	for(new i = 0; i< MAX_RCONS; i++) {
-	
+
 	    if(!strcmp(ip_address, g_iRCONData[i][e_iIP], true))
 	        return i;
 	}
@@ -209,7 +227,7 @@ static stock RCON_GetIPSlot(ip_address[]) {
 stock IsIPWhitelisted(const ip_address[]) {
 
 	for(new i = 0; i< MAX_RCONS; i++) {
-	
+
 	    if(!strcmp(ip_address, g_iRCONData[i][e_iIP], true))
 	        return 1;
 	}
@@ -219,12 +237,12 @@ stock IsIPWhitelisted(const ip_address[]) {
 stock WhitelistIP(ip_address[]) {
 
 	if(IsIPWhitelisted(ip_address)) return 0;
-	
+
 	new
 	    temp_Slot = RCON_GetIPSlot(ip_address);
 
 	if(temp_Slot != INVALID_RCON_SLOT) {
-	
+
 	    strcpy(g_iRCONData[temp_Slot][e_iIP], ip_address, MAX_IP_LEN);
 		return 1;
 	}
@@ -237,7 +255,7 @@ stock UnwhitelistIPAddress(ip_address[]) {
 	    temp_Slot = RCON_GetIPSlot(ip_address);
 
 	if(temp_Slot != INVALID_RCON_SLOT) {
-	
+
 	    g_iRCONData[temp_Slot][e_iIP][0] = '\0';
 	    return 1;
 	}
@@ -247,5 +265,4 @@ stock UnwhitelistIPAddress(ip_address[]) {
 
 forward OnRemoteRCONFail(const ipaddr[], port, const password[], const command[], reason);
 forward OnRemoteRCONExecuted(const ipaddr[], port, const password[], const command[]);
-
 


### PR DESCRIPTION
- Optimized the include completely.
- AMX size reduced from 2,447 bytes to 1,896 bytes. (In case if compiled with "OnRemoteRCONExecuted")
- Renamed "GetServerVarAsInt" to "GetConsoleVarAsInt" - I believe YSF will be updated to latest versions and since SA-MP 0.3.7-R2, it's recommended to use the latter function. 
- Slight changes over print messages.
- OnRemoteRCONExecuted now holds string values as constant.
- Include is now compatible with both filterscripts and gamemodes.
